### PR TITLE
use env var when base-url unavailable

### DIFF
--- a/lm_eval/__main__.py
+++ b/lm_eval/__main__.py
@@ -114,7 +114,7 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--output_path",
         "-o",
-        default=None,
+        default="/results/",
         type=str,
         metavar="DIR|DIR/file.json",
         help="The path to the output file where the result metrics will be saved. If the path is a directory and log_samples is true, the results will be saved in the directory. Else the parent directory will be used.",

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -4,6 +4,7 @@ import copy
 import itertools
 import json
 import logging
+import os
 from functools import cached_property
 from typing import (
     Any,
@@ -97,7 +98,7 @@ class TemplateAPI(TemplateLM):
                 'Please install these via `pip install lm-eval[api]` or `pip install -e ."[api]"`'
             )
         self.model = model or pretrained
-        self.base_url = base_url
+        self.base_url = base_url or os.environ.get('OPENAI_BASE_URL')
         self.tokenizer = tokenizer
         if not isinstance(batch_size, int) and "auto" in batch_size:
             eval_logger.warning(

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -44,6 +44,9 @@ eval_logger = logging.getLogger(__name__)
 
 LogLikelihoodInputs = Tuple[Tuple[str, str], List[int], List[int]]
 
+# Default model name to use when no model is specified
+PRECOG_MODEL = "PRECOG_MODEL"
+
 
 def _construct_openai_url(base_url: Optional[str], endpoint: str) -> Optional[str]:
     """
@@ -147,7 +150,7 @@ class TemplateAPI(TemplateLM):
                 f"Attempted to use an API model, but the required packages {missing_packages} are not installed. "
                 'Please install these via `pip install lm-eval[api]` or `pip install -e ."[api]"`'
             )
-        self.model = model or pretrained
+        self.model = model or pretrained or PRECOG_MODEL
         self.base_url = base_url or os.environ.get('OPENAI_BASE_URL')
         self.tokenizer = tokenizer
         if not isinstance(batch_size, int) and "auto" in batch_size:

--- a/lm_eval/models/api_models.py
+++ b/lm_eval/models/api_models.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 from functools import cached_property
+from urllib.parse import urljoin, urlparse
 from typing import (
     Any,
     Awaitable,
@@ -42,6 +43,55 @@ from lm_eval.models.utils import Collator, chunks, configure_pad_token
 eval_logger = logging.getLogger(__name__)
 
 LogLikelihoodInputs = Tuple[Tuple[str, str], List[int], List[int]]
+
+
+def _construct_openai_url(base_url: Optional[str], endpoint: str) -> Optional[str]:
+    """
+    Construct a proper OpenAI API URL by extracting the base from the URL and appending the endpoint.
+    This approach cleanly handles any existing paths in the base_url.
+    
+    Args:
+        base_url: The base URL (could include various paths)
+        endpoint: The specific endpoint (e.g., 'v1/completions', 'v1/chat/completions')
+    
+    Returns:
+        The properly constructed URL, or None if base_url is None
+    
+    Examples:
+        _construct_openai_url('http://localhost:8080', 'v1/completions') 
+        -> 'http://localhost:8080/v1/completions'
+        
+        _construct_openai_url('http://localhost:8080/v1/completions', 'v1/completions')
+        -> 'http://localhost:8080/v1/completions'
+        
+        _construct_openai_url('https://api.custom.com/proxy/v1/chat/completions', 'v1/completions')
+        -> 'https://api.custom.com/proxy/v1/completions'
+    """
+    if base_url is None:
+        return None
+    
+    parsed = urlparse(base_url)
+    
+    # Extract the base: scheme + netloc + any base path
+    # Remove common OpenAI API endpoints from the path to get the true base
+    path = parsed.path.rstrip('/')
+    
+    # Remove common OpenAI endpoints if they exist
+    openai_endpoints = ['/v1/completions', '/v1/chat/completions']
+    for openai_endpoint in openai_endpoints:
+        if path.endswith(openai_endpoint):
+            path = path[:-len(openai_endpoint)]
+            break
+    
+    # Construct the base URL (scheme + netloc + cleaned path)
+    base = f"{parsed.scheme}://{parsed.netloc}{path}"
+    
+    # Ensure base ends with slash and append endpoint
+    if not base.endswith('/'):
+        base += '/'
+    
+    return urljoin(base, endpoint)
+
 
 
 # utility class to keep track of json encoded chats

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -192,12 +192,14 @@ class LocalChatCompletion(LocalCompletionsAPI):
 class OpenAICompletionsAPI(LocalCompletionsAPI):
     def __init__(
         self,
-        base_url="https://api.openai.com/v1/completions",
+        base_url=None,
         tokenizer_backend="tiktoken",
         **kwargs,
     ):
         super().__init__(
-            base_url=base_url, tokenizer_backend=tokenizer_backend, **kwargs
+            base_url=base_url or os.environ.get('OPENAI_BASE_URL', 'https://api.openai.com/v1/completions'), 
+            tokenizer_backend=tokenizer_backend, 
+            **kwargs
         )
 
     @cached_property
@@ -227,7 +229,7 @@ class OpenAICompletionsAPI(LocalCompletionsAPI):
 class OpenAIChatCompletion(LocalChatCompletion):
     def __init__(
         self,
-        base_url="https://api.openai.com/v1/chat/completions",
+        base_url=None,
         tokenizer_backend=None,
         tokenized_requests=False,
         **kwargs,
@@ -237,7 +239,7 @@ class OpenAIChatCompletion(LocalChatCompletion):
                 "o1 models do not support `stop` and only support temperature=1"
             )
         super().__init__(
-            base_url=base_url,
+            base_url=base_url or os.environ.get('OPENAI_BASE_URL', 'https://api.openai.com/v1/chat/completions'),
             tokenizer_backend=tokenizer_backend,
             tokenized_requests=tokenized_requests,
             **kwargs,

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -5,7 +5,7 @@ from operator import itemgetter
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from lm_eval.api.registry import register_model
-from lm_eval.models.api_models import TemplateAPI
+from lm_eval.models.api_models import TemplateAPI, _construct_openai_url
 from lm_eval.models.utils import handle_stop_sequences
 
 
@@ -197,7 +197,10 @@ class OpenAICompletionsAPI(LocalCompletionsAPI):
         **kwargs,
     ):
         super().__init__(
-            base_url=base_url or os.environ.get('OPENAI_BASE_URL', 'https://api.openai.com/v1/completions'), 
+            base_url=base_url or _construct_openai_url(
+                os.environ.get('OPENAI_BASE_URL'), 
+                'v1/completions'
+            ) or 'https://api.openai.com/v1/completions',
             tokenizer_backend=tokenizer_backend, 
             **kwargs
         )
@@ -239,7 +242,10 @@ class OpenAIChatCompletion(LocalChatCompletion):
                 "o1 models do not support `stop` and only support temperature=1"
             )
         super().__init__(
-            base_url=base_url or os.environ.get('OPENAI_BASE_URL', 'https://api.openai.com/v1/chat/completions'),
+            base_url=base_url or _construct_openai_url(
+                os.environ.get('OPENAI_BASE_URL'), 
+                'v1/chat/completions'
+            ) or 'https://api.openai.com/v1/chat/completions',
             tokenizer_backend=tokenizer_backend,
             tokenized_requests=tokenized_requests,
             **kwargs,

--- a/lm_eval/models/openai_completions.py
+++ b/lm_eval/models/openai_completions.py
@@ -21,7 +21,12 @@ class LocalCompletionsAPI(TemplateAPI):
         **kwargs,
     ):
         super().__init__(
-            base_url=base_url, tokenizer_backend=tokenizer_backend, **kwargs
+            base_url=base_url or _construct_openai_url(
+                os.environ.get('OPENAI_BASE_URL'), 
+                'v1/completions'
+            ),
+            tokenizer_backend=tokenizer_backend, 
+            **kwargs
         )
 
     def _create_payload(
@@ -117,7 +122,10 @@ class LocalChatCompletion(LocalCompletionsAPI):
             "chat-completions endpoint requires the `--apply_chat_template` flag."
         )
         super().__init__(
-            base_url=base_url,
+            base_url=base_url or _construct_openai_url(
+                os.environ.get('OPENAI_BASE_URL'), 
+                'v1/chat/completions'
+            ),
             tokenizer_backend=tokenizer_backend,
             tokenized_requests=tokenized_requests,
             **kwargs,


### PR DESCRIPTION
`openai-completion` will now use `os.environ['OPENAI_BASE_URL']` if `base_url` is not provided.